### PR TITLE
Add Next.js skeleton app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+.next
+.env.local

--- a/README.md
+++ b/README.md
@@ -1,3 +1,40 @@
-# te-example1
+# MCP Observability
 
-This is the first file in this repo. 
+This project is a minimal example of a SaaS style application for managing and testing MCP servers. It is built with [Next.js](https://nextjs.org/) and uses a serverless Postgres database.
+
+## Development
+
+1. Install dependencies (requires Node.js 18+)
+
+```bash
+pnpm install
+```
+
+2. Create a Postgres database and set the `DATABASE_URL` environment variable. When running locally you can add a `.env.local` file with:
+
+```
+DATABASE_URL=postgres://user:pass@host/dbname
+PGSSL=true
+```
+
+3. Start the development server:
+
+```bash
+pnpm dev
+```
+
+Open <http://localhost:3000> in your browser to see the app.
+
+## Notes
+
+The API route in `pages/api/servers.ts` stores server names and URLs in a table called `servers`. You must create this table in your database:
+
+```sql
+CREATE TABLE servers (
+  id SERIAL PRIMARY KEY,
+  name TEXT NOT NULL,
+  url TEXT NOT NULL
+);
+```
+
+This project is intentionally small and meant as a starting point for building an observability and testing platform for MCP servers, similar to Postman but specialized for MCP.

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -1,0 +1,15 @@
+import { Pool } from 'pg'
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  ssl: process.env.PGSSL === 'true' ? { rejectUnauthorized: false } : undefined
+})
+
+export async function query(text: string, params?: any[]) {
+  const client = await pool.connect()
+  try {
+    return await client.query(text, params)
+  } finally {
+    client.release()
+  }
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "mcp-observability",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "pg": "^8.11.3"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,5 @@
+import type { AppProps } from 'next/app'
+
+export default function App({ Component, pageProps }: AppProps) {
+  return <Component {...pageProps} />
+}

--- a/pages/api/servers.ts
+++ b/pages/api/servers.ts
@@ -1,0 +1,11 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { query } from '../../lib/db'
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    const { name, url } = req.body
+    await query('INSERT INTO servers (name, url) VALUES ($1, $2)', [name, url])
+  }
+  const servers = await query('SELECT id, name, url FROM servers ORDER BY id DESC')
+  res.status(200).json(servers.rows)
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+
+interface Server {
+  id: number
+  name: string
+  url: string
+}
+
+export default function Home() {
+  const [servers, setServers] = useState<Server[]>([])
+  const [name, setName] = useState('')
+  const [url, setUrl] = useState('')
+
+  useEffect(() => {
+    fetch('/api/servers')
+      .then(res => res.json())
+      .then(setServers)
+      .catch(console.error)
+  }, [])
+
+  const handleAdd = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const res = await fetch('/api/servers', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, url })
+    })
+    if (res.ok) {
+      setName('')
+      setUrl('')
+      const data = await res.json()
+      setServers(data)
+    }
+  }
+
+  return (
+    <div style={{ maxWidth: 600, margin: '0 auto', padding: '1rem' }}>
+      <h1>MCP Observability</h1>
+      <form onSubmit={handleAdd} style={{ marginBottom: '1rem' }}>
+        <input
+          value={name}
+          onChange={e => setName(e.target.value)}
+          placeholder="Server name"
+          required
+        />
+        <input
+          value={url}
+          onChange={e => setUrl(e.target.value)}
+          placeholder="Server URL"
+          required
+        />
+        <button type="submit">Add</button>
+      </form>
+      <ul>
+        {servers.map(server => (
+          <li key={server.id}>{server.name} - {server.url}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,24 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+
+packages:
+
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+snapshots:
+
+  typescript@5.8.3: {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- add minimal Next.js project
- connect to a serverless Postgres instance via `pg`
- basic UI to save and display MCP server endpoints
- document setup and development workflow

## Testing
- `pnpm test` *(fails: Missing script)*